### PR TITLE
Extracting code into functions

### DIFF
--- a/spectrogram/convert.py
+++ b/spectrogram/convert.py
@@ -1,4 +1,5 @@
 import pathlib
+import shutil
 from pathlib import Path
 
 import librosa.display
@@ -10,6 +11,34 @@ from sample_downloader.download import MUSDB_SAMPLE_OUTPUT_PATH
 
 SPECTROGRAM_SAMPLE_OUTPUT_PATH= "{}/sample_data/spectograms"
 
+
+# --- Average stereo to mono for all signals ---
+def stereo_to_mono(signal):
+    if signal.ndim == 2 and signal.shape[1] == 2:
+        return np.mean(signal, axis=1)
+    return signal
+
+
+# --- Helper function to create normalized mel spectrogram ---
+def compute_normalized_mel(y, sr):
+    mel_spec = librosa.feature.melspectrogram(y=y, sr=sr, n_mels=128)
+    mel_spec_db = librosa.power_to_db(mel_spec, ref=np.max)
+    mel_min = mel_spec_db.min()
+    mel_max = mel_spec_db.max()
+    mel_norm = (mel_spec_db - mel_min) / (mel_max - mel_min)
+    return mel_norm, mel_spec_db
+
+
+# --- Helper function to plot and save spectrograms without borders ---
+def save_spectrogram_image(mel_db, save_path, rate):
+    fig, ax = plt.subplots(figsize=(12, 8))
+    librosa.display.specshow(mel_db, sr=rate, x_axis='time', y_axis='mel', ax=ax)
+    plt.axis('off')
+    plt.margins(0)
+    plt.subplots_adjust(0, 0, 1, 1)
+    plt.savefig(save_path, bbox_inches='tight', pad_inches=0)
+    plt.close()
+
 def convert():
     # Get the current working directory (assuming you run the script from project root)
     project_root = Path.cwd()
@@ -17,8 +46,10 @@ def convert():
     # Define output directory for spectrogram files
     output_dir = Path(SPECTROGRAM_SAMPLE_OUTPUT_PATH.format(project_root))
 
-    # Create the output directory if it doesn't exist
-    output_dir.mkdir(parents=True, exist_ok=True)
+    # --- Clean output directory ---
+    if output_dir.exists():
+        shutil.rmtree(output_dir)  # Delete everything inside output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)  # Recreate fresh
 
     # Define the MUSDB samples root directory
     musdb_root = Path(MUSDB_SAMPLE_OUTPUT_PATH.format(project_root))
@@ -27,55 +58,42 @@ def convert():
     for split in ['train', 'test']:
         split_path = musdb_root / split
 
-        # Find all .stem.mp4 files inside the split directory
         for file in split_path.glob('*.stem.mp4'):
             print(f"Processing {file}")
 
             # --- Load audio stems ---
-            # stempeg.read_stems loads all stems into a numpy array
-            # shape: (num_stems, samples, channels)
             audio, rate = stempeg.read_stems(str(file))
 
-            # --- Mix all stems together into a single audio track ---
-            mix = np.mean(audio, axis=0)  # Collapse across stems
+            # --- Extract relevant parts ---
+            mix = audio[0]  # full mix
+            drums = audio[1]
+            bass = audio[2]
+            other = audio[3]
+            vocals = audio[4]
 
-            # --- If stereo (2 channels), average them to mono ---
-            if mix.ndim == 2 and mix.shape[1] == 2:
-                mix = np.mean(mix, axis=1)
+            # --- Create instruments by adding drums, bass, and other ---
+            instruments = drums + bass + other
 
-            # --- Create MEL spectrogram ---
-            # Converts waveform into Mel-scaled spectrogram (human-like frequency perception)
-            mel_spec = librosa.feature.melspectrogram(y=mix, sr=rate, n_mels=128)
+            mix = stereo_to_mono(mix)
+            vocals = stereo_to_mono(vocals)
+            instruments = stereo_to_mono(instruments)
 
-            # --- Convert power spectrogram (amplitude^2) to decibel (dB) units ---
-            mel_spec_db = librosa.power_to_db(mel_spec, ref=np.max)
+            # --- Compute normalized mel spectrograms and original dB spectrograms ---
+            mix_mel_norm, mix_mel_db = compute_normalized_mel(mix, rate)
+            vocals_mel_norm, vocals_mel_db = compute_normalized_mel(vocals, rate)
+            instruments_mel_norm, instruments_mel_db = compute_normalized_mel(instruments, rate)
 
-            # --- Normalize mel spectrogram to [0,1] range ---
-            # Important for CNN training: smaller, bounded inputs make models train faster and more stable
-            mel_spec_db_min = mel_spec_db.min()
-            mel_spec_db_max = mel_spec_db.max()
-            mel_spec_db_norm = (mel_spec_db - mel_spec_db_min) / (mel_spec_db_max - mel_spec_db_min)
+            # --- Save normalized mel spectrograms as .npy files ---
+            np.save(output_dir / f"{file.stem}_mix.npy", mix_mel_norm)
+            np.save(output_dir / f"{file.stem}_vocals.npy", vocals_mel_norm)
+            np.save(output_dir / f"{file.stem}_instruments.npy", instruments_mel_norm)
 
-            # --- Save the normalized Mel spectrogram as a .npy file ---
-            # This is what the CNN will actually use as input features
-            npy_output_file = output_dir / f"{file.stem}_mel_spectrogram.npy"
-            np.save(npy_output_file, mel_spec_db_norm)
+            # --- Save spectrogram plots as .png files ---
+            save_spectrogram_image(mix_mel_db, output_dir / f"{file.stem}_mix.png", rate)
+            save_spectrogram_image(vocals_mel_db, output_dir / f"{file.stem}_vocals.png", rate)
+            save_spectrogram_image(instruments_mel_db, output_dir / f"{file.stem}_instruments.png", rate)
 
-            # --- (Optional) Save a plot for human inspection ---
-            # Plot original dB mel spectrogram (not normalized) for easier visual checks
-            plt.figure(figsize=(12, 8))
-            librosa.display.specshow(
-                mel_spec_db, sr=rate, x_axis='time', y_axis='mel'
-            )
-            plt.colorbar(format='%+2.0f dB')  # Color bar shows dB levels
-            plt.title(f'Mel Spectrogram - {file.stem}')
-            plt.tight_layout()
-
-            # Save plot as PNG image
-            png_output_file = output_dir / f"{file.stem}_mel_spectrogram.png"
-            plt.savefig(png_output_file)
-            plt.close()
-
+            print(f"Saved .npy and .png for {file.stem}")
 
 if __name__ == "__main__":
     convert()


### PR DESCRIPTION
This pull request refactors and enhances the `convert.py` script in the `spectrogram` module to improve functionality, maintainability, and output quality. Key changes include the addition of helper functions for signal processing, improved spectrogram generation and normalization, and enhanced output handling for both `.npy` and `.png` files.

### New Helper Functions for Signal Processing:
* Added `stereo_to_mono` to handle stereo-to-mono conversion for signals, improving reusability and code clarity.
* Added `compute_normalized_mel` to compute normalized mel spectrograms and their decibel (dB) counterparts, streamlining spectrogram generation.
* Added `save_spectrogram_image` to save spectrogram plots as images without borders, improving visualization consistency.

### Refactoring of `convert()` Function:
* Replaced inline operations with helper functions for stereo-to-mono conversion and spectrogram computation, reducing code duplication.
* Updated the logic to handle individual audio stems (`mix`, `vocals`, `instruments`) separately, enabling more granular processing and output.

### Output Directory Management:
* Introduced cleanup of the output directory (`shutil.rmtree`) before processing to ensure a fresh start for each run.

### Improved Output Handling:
* Changed `.npy` file generation to save normalized mel spectrograms for `mix`, `vocals`, and `instruments` separately.
* Replaced manual plotting with the new `save_spectrogram_image` function for consistent and clean `.png` file generation.