### PR TITLE
Add waveform converter

### DIFF
--- a/spectrogram/convert.py
+++ b/spectrogram/convert.py
@@ -1,4 +1,5 @@
 import pathlib
+import shutil
 from pathlib import Path
 
 import librosa.display
@@ -10,6 +11,34 @@ from sample_downloader.download import MUSDB_SAMPLE_OUTPUT_PATH
 
 SPECTROGRAM_SAMPLE_OUTPUT_PATH= "{}/sample_data/spectograms"
 
+
+# --- Average stereo to mono for all signals ---
+def stereo_to_mono(signal):
+    if signal.ndim == 2 and signal.shape[1] == 2:
+        return np.mean(signal, axis=1)
+    return signal
+
+
+# --- Helper function to create normalized mel spectrogram ---
+def compute_normalized_mel(y, sr):
+    mel_spec = librosa.feature.melspectrogram(y=y, sr=sr, n_mels=128)
+    mel_spec_db = librosa.power_to_db(mel_spec, ref=np.max)
+    mel_min = mel_spec_db.min()
+    mel_max = mel_spec_db.max()
+    mel_norm = (mel_spec_db - mel_min) / (mel_max - mel_min)
+    return mel_norm, mel_spec_db
+
+
+# --- Helper function to plot and save spectrograms without borders ---
+def save_spectrogram_image(mel_db, save_path, rate):
+    fig, ax = plt.subplots(figsize=(12, 8))
+    librosa.display.specshow(mel_db, sr=rate, x_axis='time', y_axis='mel', ax=ax)
+    plt.axis('off')
+    plt.margins(0)
+    plt.subplots_adjust(0, 0, 1, 1)
+    plt.savefig(save_path, bbox_inches='tight', pad_inches=0)
+    plt.close()
+
 def convert():
     # Get the current working directory (assuming you run the script from project root)
     project_root = Path.cwd()
@@ -17,8 +46,10 @@ def convert():
     # Define output directory for spectrogram files
     output_dir = Path(SPECTROGRAM_SAMPLE_OUTPUT_PATH.format(project_root))
 
-    # Create the output directory if it doesn't exist
-    output_dir.mkdir(parents=True, exist_ok=True)
+    # --- Clean output directory ---
+    if output_dir.exists():
+        shutil.rmtree(output_dir)  # Delete everything inside output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)  # Recreate fresh
 
     # Define the MUSDB samples root directory
     musdb_root = Path(MUSDB_SAMPLE_OUTPUT_PATH.format(project_root))
@@ -27,55 +58,42 @@ def convert():
     for split in ['train', 'test']:
         split_path = musdb_root / split
 
-        # Find all .stem.mp4 files inside the split directory
         for file in split_path.glob('*.stem.mp4'):
             print(f"Processing {file}")
 
             # --- Load audio stems ---
-            # stempeg.read_stems loads all stems into a numpy array
-            # shape: (num_stems, samples, channels)
             audio, rate = stempeg.read_stems(str(file))
 
-            # --- Mix all stems together into a single audio track ---
-            mix = np.mean(audio, axis=0)  # Collapse across stems
+            # --- Extract relevant parts ---
+            mix = audio[0]  # full mix
+            drums = audio[1]
+            bass = audio[2]
+            other = audio[3]
+            vocals = audio[4]
 
-            # --- If stereo (2 channels), average them to mono ---
-            if mix.ndim == 2 and mix.shape[1] == 2:
-                mix = np.mean(mix, axis=1)
+            # --- Create instruments by adding drums, bass, and other ---
+            instruments = drums + bass + other
 
-            # --- Create MEL spectrogram ---
-            # Converts waveform into Mel-scaled spectrogram (human-like frequency perception)
-            mel_spec = librosa.feature.melspectrogram(y=mix, sr=rate, n_mels=128)
+            mix = stereo_to_mono(mix)
+            vocals = stereo_to_mono(vocals)
+            instruments = stereo_to_mono(instruments)
 
-            # --- Convert power spectrogram (amplitude^2) to decibel (dB) units ---
-            mel_spec_db = librosa.power_to_db(mel_spec, ref=np.max)
+            # --- Compute normalized mel spectrograms and original dB spectrograms ---
+            mix_mel_norm, mix_mel_db = compute_normalized_mel(mix, rate)
+            vocals_mel_norm, vocals_mel_db = compute_normalized_mel(vocals, rate)
+            instruments_mel_norm, instruments_mel_db = compute_normalized_mel(instruments, rate)
 
-            # --- Normalize mel spectrogram to [0,1] range ---
-            # Important for CNN training: smaller, bounded inputs make models train faster and more stable
-            mel_spec_db_min = mel_spec_db.min()
-            mel_spec_db_max = mel_spec_db.max()
-            mel_spec_db_norm = (mel_spec_db - mel_spec_db_min) / (mel_spec_db_max - mel_spec_db_min)
+            # --- Save normalized mel spectrograms as .npy files ---
+            np.save(output_dir / f"{file.stem}_mix.npy", mix_mel_norm)
+            np.save(output_dir / f"{file.stem}_vocals.npy", vocals_mel_norm)
+            np.save(output_dir / f"{file.stem}_instruments.npy", instruments_mel_norm)
 
-            # --- Save the normalized Mel spectrogram as a .npy file ---
-            # This is what the CNN will actually use as input features
-            npy_output_file = output_dir / f"{file.stem}_mel_spectrogram.npy"
-            np.save(npy_output_file, mel_spec_db_norm)
+            # --- Save spectrogram plots as .png files ---
+            save_spectrogram_image(mix_mel_db, output_dir / f"{file.stem}_mix.png", rate)
+            save_spectrogram_image(vocals_mel_db, output_dir / f"{file.stem}_vocals.png", rate)
+            save_spectrogram_image(instruments_mel_db, output_dir / f"{file.stem}_instruments.png", rate)
 
-            # --- (Optional) Save a plot for human inspection ---
-            # Plot original dB mel spectrogram (not normalized) for easier visual checks
-            plt.figure(figsize=(12, 8))
-            librosa.display.specshow(
-                mel_spec_db, sr=rate, x_axis='time', y_axis='mel'
-            )
-            plt.colorbar(format='%+2.0f dB')  # Color bar shows dB levels
-            plt.title(f'Mel Spectrogram - {file.stem}')
-            plt.tight_layout()
-
-            # Save plot as PNG image
-            png_output_file = output_dir / f"{file.stem}_mel_spectrogram.png"
-            plt.savefig(png_output_file)
-            plt.close()
-
+            print(f"Saved .npy and .png for {file.stem}")
 
 if __name__ == "__main__":
     convert()

--- a/spectrogram/convert.py
+++ b/spectrogram/convert.py
@@ -10,6 +10,7 @@ import stempeg
 from sample_downloader.download import MUSDB_SAMPLE_OUTPUT_PATH
 
 SPECTROGRAM_SAMPLE_OUTPUT_PATH= "{}/sample_data/spectograms"
+WAVEFORM_SAMPLE_OUTPUT_PATH= "{}/sample_data/waveforms"
 
 
 # --- Average stereo to mono for all signals ---
@@ -39,17 +40,32 @@ def save_spectrogram_image(mel_db, save_path, rate):
     plt.savefig(save_path, bbox_inches='tight', pad_inches=0)
     plt.close()
 
+# --- Helper function to plot and save waveform without borders ---
+def save_waveform_image(signal, save_path, rate):
+    fig, ax = plt.subplots(figsize=(12, 3))  # waveform doesn't need 8 vertical inches
+    librosa.display.waveshow(signal, sr=rate, ax=ax)
+    plt.axis('off')
+    plt.margins(0)
+    plt.subplots_adjust(0, 0, 1, 1)
+    plt.savefig(save_path, bbox_inches='tight', pad_inches=0)
+    plt.close()
+
 def convert():
     # Get the current working directory (assuming you run the script from project root)
     project_root = Path.cwd()
 
     # Define output directory for spectrogram files
-    output_dir = Path(SPECTROGRAM_SAMPLE_OUTPUT_PATH.format(project_root))
+    spectrogram_output_dir = Path(SPECTROGRAM_SAMPLE_OUTPUT_PATH.format(project_root))
+    waveform_output_dir = Path(WAVEFORM_SAMPLE_OUTPUT_PATH.format(project_root))
 
-    # --- Clean output directory ---
-    if output_dir.exists():
-        shutil.rmtree(output_dir)  # Delete everything inside output_dir
-    output_dir.mkdir(parents=True, exist_ok=True)  # Recreate fresh
+    # --- Clean output directories ---
+    if spectrogram_output_dir.exists():
+        shutil.rmtree(spectrogram_output_dir)  # Delete everything inside spectrogram_output_dir
+    spectrogram_output_dir.mkdir(parents=True, exist_ok=True)  # Recreate fresh
+
+    if waveform_output_dir.exists():
+        shutil.rmtree(waveform_output_dir)  # Delete everything inside spectrogram_output_dir
+    waveform_output_dir.mkdir(parents=True, exist_ok=True)  # Recreate fresh
 
     # Define the MUSDB samples root directory
     musdb_root = Path(MUSDB_SAMPLE_OUTPUT_PATH.format(project_root))
@@ -84,14 +100,19 @@ def convert():
             instruments_mel_norm, instruments_mel_db = compute_normalized_mel(instruments, rate)
 
             # --- Save normalized mel spectrograms as .npy files ---
-            np.save(output_dir / f"{file.stem}_mix.npy", mix_mel_norm)
-            np.save(output_dir / f"{file.stem}_vocals.npy", vocals_mel_norm)
-            np.save(output_dir / f"{file.stem}_instruments.npy", instruments_mel_norm)
+            np.save(spectrogram_output_dir / f"{file.stem}_mix.npy", mix_mel_norm)
+            np.save(spectrogram_output_dir / f"{file.stem}_vocals.npy", vocals_mel_norm)
+            np.save(spectrogram_output_dir / f"{file.stem}_instruments.npy", instruments_mel_norm)
 
             # --- Save spectrogram plots as .png files ---
-            save_spectrogram_image(mix_mel_db, output_dir / f"{file.stem}_mix.png", rate)
-            save_spectrogram_image(vocals_mel_db, output_dir / f"{file.stem}_vocals.png", rate)
-            save_spectrogram_image(instruments_mel_db, output_dir / f"{file.stem}_instruments.png", rate)
+            save_spectrogram_image(mix_mel_db, spectrogram_output_dir / f"{file.stem}_mix.png", rate)
+            save_spectrogram_image(vocals_mel_db, spectrogram_output_dir / f"{file.stem}_vocals.png", rate)
+            save_spectrogram_image(instruments_mel_db, spectrogram_output_dir / f"{file.stem}_instruments.png", rate)
+
+            # --- Save waveform plots as .png files ---
+            save_waveform_image(vocals, waveform_output_dir / f"{file.stem}_vocals_waveform.png", rate)
+            save_waveform_image(instruments, waveform_output_dir / f"{file.stem}_instruments_waveform.png", rate)
+            save_waveform_image(mix, waveform_output_dir / f"{file.stem}_mix_waveform.png", rate)
 
             print(f"Saved .npy and .png for {file.stem}")
 


### PR DESCRIPTION
This pull request refactors and enhances the `convert.py` script in the `spectrogram` module to improve functionality, modularity, and output comprehensiveness. Key changes include the addition of helper functions for audio processing, expanded output generation for spectrograms and waveforms, and improved directory management for output files.

### Audio processing enhancements:
* Added the `stereo_to_mono` function to handle stereo-to-mono conversion for signals, ensuring consistent input for spectrogram computation.
* Extracted individual audio components (mix, drums, bass, other, vocals) from stems and combined them into "instruments" for more granular spectrogram analysis.

### Spectrogram and waveform generation:
* Introduced the `compute_normalized_mel` function to compute normalized mel spectrograms and their dB representations, improving reusability and code clarity.
* Added `save_spectrogram_image` and `save_waveform_image` helper functions to generate and save spectrogram and waveform visualizations without borders.
* Expanded output to include normalized mel spectrograms (`.npy` files), spectrogram plots (`.png` files), and waveform plots for mix, vocals, and instruments.

### Output directory management:
* Introduced a new `WAVEFORM_SAMPLE_OUTPUT_PATH` for saving waveform-related outputs alongside spectrograms.
* Refactored directory handling to clean and recreate output directories (`spectrogram_output_dir` and `waveform_output_dir`) at the start of each run, ensuring fresh outputs.