### PR TITLE
feat: h5 dataset support and spectrogram data augmentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ interpretability/
 eval/
 output/
 *.log
+*.h5
+sample_data/h5/

--- a/README.md
+++ b/README.md
@@ -108,6 +108,25 @@ While sample data scripts are provided, this project is designed with the [MUSDB
 - Download it manually if desired.
 - You will need to adapt the `converter/convert.py` script or your workflow to process the MUSDB18 structure and place the generated spectrograms in a location accessible by `train.py`.
 
+## 📦 Dataset .h5 (MUSDB18)
+
+Este proyecto soporta entrenamiento directamente desde archivos `.h5` con espectrogramas preprocesados (por ejemplo, MUSDB18).
+
+- Coloca los archivos `.h5` en la carpeta `sample_data/h5/`.
+- Ejemplo de ruta: `sample_data/h5/musdb18_train_spectrograms.h5`
+- **No subas estos archivos al repositorio.**
+
+Para usar el dataset `.h5` en el entrenamiento:
+
+```python
+from u_net_stft.h5_dataset import H5SpectrogramDataset
+from u_net_stft.augment import spec_augment
+
+dataset = H5SpectrogramDataset('sample_data/h5/musdb18_train_spectrograms.h5', transform=spec_augment)
+```
+
+Puedes aplicar augmentations como SpecAugment directamente sobre los espectrogramas durante el entrenamiento.
+
 ## ⏳ Status
 
 - Core training with STFT implemented.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ filelock==3.18.0
 fonttools==4.57.0
 fsspec==2025.3.2
 future==1.0.0
+h5py
 idna==3.10
 iniconfig==2.1.0
 Jinja2==3.1.6

--- a/u_net_stft/augment.py
+++ b/u_net_stft/augment.py
@@ -1,0 +1,32 @@
+import torch
+import random
+
+
+def time_mask(spec, max_width=20):
+    t = spec.shape[-1]
+    width = random.randint(0, max_width)
+    start = random.randint(0, t - width) if t - width > 0 else 0
+    spec[..., start:start+width] = 0
+    return spec
+
+
+def freq_mask(spec, max_width=10):
+    f = spec.shape[-2]
+    width = random.randint(0, max_width)
+    start = random.randint(0, f - width) if f - width > 0 else 0
+    spec[..., start:start+width, :] = 0
+    return spec
+
+
+def time_shift(spec, max_shift=10):
+    shift = random.randint(-max_shift, max_shift)
+    return torch.roll(spec, shifts=shift, dims=-1)
+
+
+def spec_augment(mix, vocals, instruments):
+    for fn in [time_mask, freq_mask, time_shift]:
+        if random.random() < 0.5:
+            mix = fn(mix.clone())
+            vocals = fn(vocals.clone())
+            instruments = fn(instruments.clone())
+    return mix, vocals, instruments

--- a/u_net_stft/h5_dataset.py
+++ b/u_net_stft/h5_dataset.py
@@ -1,0 +1,34 @@
+import torch
+from torch.utils.data import Dataset
+import h5py
+import numpy as np
+
+
+class H5SpectrogramDataset(Dataset):
+    def __init__(self, h5_path, transform=None):
+        self.h5_path = h5_path
+        self.transform = transform
+        with h5py.File(h5_path, 'r') as f:
+            # Asumimos que todas las keys están en 'mix' y existen en los otros grupos
+            self.keys = list(f['mix'].keys())
+
+    def __len__(self):
+        return len(self.keys)
+
+    def __getitem__(self, idx):
+        key = self.keys[idx]
+        with h5py.File(self.h5_path, 'r') as f:
+            mix = f['mix'][key][()]
+            vocals = f['vocals'][key][()]
+            instruments = f['instruments'][key][()]
+        # Añade canal (1, F, T)
+        mix = np.expand_dims(mix, 0)
+        vocals = np.expand_dims(vocals, 0)
+        instruments = np.expand_dims(instruments, 0)
+        # A tensor
+        mix = torch.tensor(mix, dtype=torch.float32)
+        vocals = torch.tensor(vocals, dtype=torch.float32)
+        instruments = torch.tensor(instruments, dtype=torch.float32)
+        if self.transform:
+            mix, vocals, instruments = self.transform(mix, vocals, instruments)
+        return mix, vocals, instruments


### PR DESCRIPTION
This PR adds support for training directly from .h5 spectrogram datasets (MUSDB18 style) and applies online SpecAugment-style data augmentation.

- New H5SpectrogramDataset for group/key-based .h5 structure
- Online time/frequency masking and shifting (SpecAugment)
- Updated README and .gitignore
- Backwards compatible with .npy pipeline